### PR TITLE
USART0_Handler fix

### DIFF
--- a/DmxDue.cpp
+++ b/DmxDue.cpp
@@ -268,7 +268,7 @@ uint8_t dmx_tx_buffer1[DMX_TX_MAX];
 DmxDue DmxDue1(USART0, USART0_IRQn, ID_USART0, dmx_rx_buffer1, dmx_tx_buffer1);
 
 // IT handlers
-void USART0_Handler( void )
+void myUSART0_Handler( void )
 {
   DmxDue1.IrqHandler() ;
 }


### PR DESCRIPTION
.pioenvs/due/libFrameworkArduinoVariant.a(variant.cpp.o): In function `USART0_Handler':
variant.cpp:(.text.USART0_Handler+0x0): multiple definition of `USART0_Handler'
.pioenvs/due/lib3d5/libDmxDue.a(DmxDue.cpp.o):DmxDue.cpp:(.text.USART0_Handler+0x0): first defined here